### PR TITLE
fix: serial mode fails with NameError due to missing pyserial and unset baudrate

### DIFF
--- a/rehau_neasmart2.0_gateway/rootfs/src/main.py
+++ b/rehau_neasmart2.0_gateway/rootfs/src/main.py
@@ -481,6 +481,7 @@ async def run_modbus_server(server_context, server_addr, conn_type):
             identity=identity,
             port=server_addr,
             framer=ModbusRtuFramer,
+            baudrate=const.NEASMART_SYSBUS_BAUD,
             stopbits=const.NEASMART_SYSBUS_STOP_BITS,
             bytesize=const.NEASMART_SYSBUS_DATA_BITS,
             parity=const.NEASMART_SYSBUS_PARITY,

--- a/rehau_neasmart2.0_gateway/rootfs/src/requirements.txt
+++ b/rehau_neasmart2.0_gateway/rootfs/src/requirements.txt
@@ -1,3 +1,4 @@
 pymodbus~=3.3.1
 Flask~=2.3.2
 sqlitedict~=2.1.0
+pyserial~=3.5


### PR DESCRIPTION
## Problem
When configuring `server_type: serial`, the add-on crashes on startup with: NameError: name 'serial' is not defined

This happens because `pyserial` is never installed — it's a required dependency
for pymodbus's serial transport but is missing from `requirements.txt`.

After adding `pyserial`, the add-on starts but never receives any data from the
SYSBUS, despite correct wiring (verified with a raw serial capture showing valid
RTU frames addressed to units 240/241). Root cause: `StartAsyncSerialServer` in
`run_modbus_server` never passes `baudrate=const.NEASMART_SYSBUS_BAUD`, so
pymodbus defaults to 9600 baud instead of the SYSBUS's actual 38400 baud.

## Fix
- Add `pyserial~=3.5` to `requirements.txt`
- Pass `baudrate=const.NEASMART_SYSBUS_BAUD` to `StartAsyncSerialServer`

Tested on a real Nea Smart 2.0 installation via USB-RS485 adapter (Waveshare
FT232R + SP485EEN), confirmed working end-to-end with real zone data.