### PR TITLE
ci: pin Ruff for reproducible checks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r rehau_neasmart2.0_gateway/rootfs/src/requirements.txt pytest ruff
+          python -m pip install -r rehau_neasmart2.0_gateway/rootfs/src/requirements.txt pytest ruff==0.15.21
 
       - name: Run tests
         run: pytest -q


### PR DESCRIPTION
Pin Ruff to 0.15.21, the version used by the last successful test workflow. Ruff 0.16.0 changed its default rule set and made unchanged code fail after dependency resolution drift.